### PR TITLE
fix for SignatureDoesNotMatch in eu-west-1

### DIFF
--- a/certificate.py
+++ b/certificate.py
@@ -21,7 +21,7 @@ l.setLevel(logging.INFO)
 
 def send(event):
     l.info(event)
-    requests.put(event['ResponseURL'], json=event)
+    requests.put(event['ResponseURL'], json=event, headers={'content-type': ''})
 
 
 def create_cert(props, i_token):


### PR DESCRIPTION
when executed in eu-west-1 we get this error from Cloudformation:

<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>XXX</AWSAccessKeyId><StringToSign>PUT

Setting the Content-Type to empty string fixes the issue