### PR TITLE
Fix linting warnings relating to AWS partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ CustomAcmCertificateLambdaExecutionRole:
                 - acm:RemoveTagsFromCertificate
               Effect: Allow
               Resource:
-                - !Sub 'arn:aws:acm:*:${AWS::AccountId}:certificate/*'
+                - !Sub 'arn:${AWS::Partition}:acm:*:${AWS::AccountId}:certificate/*'
             - Action:
                 - acm:RequestCertificate
                 - acm:ListTagsForCertificate

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -66,7 +66,7 @@
                                     "Effect": "Allow",
                                     "Resource": [
                                         {
-                                            "Fn::Sub": "arn:aws:acm:*:${AWS::AccountId}:certificate/*"
+                                            "Fn::Sub": "arn:${AWS::Partition}:acm:*:${AWS::AccountId}:certificate/*"
                                         }
                                     ]
                                 },

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -61,7 +61,7 @@ Resources:
                   - acm:RemoveTagsFromCertificate
                 Effect: Allow
                 Resource:
-                  - !Sub 'arn:aws:acm:*:${AWS::AccountId}:certificate/*'
+                  - !Sub 'arn:${AWS::Partition}:acm:*:${AWS::AccountId}:certificate/*'
               - Action:
                   - acm:RequestCertificate
                   - acm:ListTagsForCertificate

--- a/src/troposphere_dns_certificate/certificatemanager.py
+++ b/src/troposphere_dns_certificate/certificatemanager.py
@@ -55,7 +55,7 @@ def add_helpers(template):
                                         Action('acm', 'RemoveTagsFromCertificate'),
 
                                     ],
-                                    Resource=[Sub('arn:aws:acm:*:${AWS::AccountId}:certificate/*')],
+                                    Resource=[Sub('arn:${AWS::Partition}:acm:*:${AWS::AccountId}:certificate/*')],
                                 ),
                                 Statement(
                                     Effect=Allow,


### PR DESCRIPTION
The CloudFormation stacks currently generate a `cfn-lint` warning "[cfn-lint] I3042: ARN in Resource CustomAcmCertificateLambdaExecutionRole contains hardcoded Partition in ARN or incorrectly placed Pseudo Parameters".

This comes from constructs like
```yaml
!Sub 'arn:aws:acm:*:${AWS::AccountId}:certificate/*'
```
where the `:aws:` in principle could be `:aws-cn:` or `:aws-us-gov:`. The fix is to insert the pseudo parameter `${AWS::Partition}` like so:
```yaml
!Sub 'arn:${AWS::Partition}:acm:*:${AWS::AccountId}:certificate/*'
```
I have made this substitution where it seemed reasonable, but was not able to run the tests. This PR doesn't fix anything functional -- it's only intended to get rid of the warnings.

Also, thanks for making this! This resource genuinely is a blessing.